### PR TITLE
Remove redundant to_langgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,9 @@ async def flaky_api_call(endpoint: str) -> dict:
 Convert existing AsyncFlow tasks to LangChain tools:
 
 ```python
-@flow.function_task
+@integration.asyncflow_tool
 async def existing_task(data: str) -> str:
     return f"Processed: {data}"
-
-# Convert to LangChain tool
-tool = integration.to_langgraph_tool(existing_task)
 ```
 
 ## Examples
@@ -273,10 +270,6 @@ Create a complete workflow from a chain of Academy agents.
 #### `asyncflow_tool(func=None, retry=None)`
 
 Decorator to register an async function as both AsyncFlow task and LangChain tool.
-
-#### `to_langgraph_tool(asyncflow_task, retry=None)`
-
-Convert an existing AsyncFlow task to a LangChain tool.
 
 ### RetryConfig
 

--- a/src/flowgentic/langgraph.py
+++ b/src/flowgentic/langgraph.py
@@ -4,8 +4,7 @@ with built-in retries, backoff, and timeouts.
 
 Key features:
 - Define AsyncFlow tasks with `@flow.function_task`
-- Expose as LangChain tools via `@integration.asyncflow_tool(...)` or
-  `integration.to_langgraph_tool(task, ...)`
+- Expose as LangChain tools via `@integration.asyncflow_tool(...)`
 - Sensible defaults for fault tolerance (no config required)
 """
 
@@ -168,24 +167,7 @@ class LangGraphIntegration:
             return decorate(func)
         return decorate
 
-    def to_langgraph_tool(self, asyncflow_task: Callable, *, retry: Optional[RetryConfig] = None) -> Callable:
-        """Create a LangChain tool from an existing AsyncFlow task with retries.
 
-        Args:
-            asyncflow_task: An already decorated AsyncFlow task
-            retry: Optional per-tool retry config (defaults applied if None)
-        """
-        retry_cfg = retry or self.default_retry
-
-        @wraps(asyncflow_task)
-        async def wrapper(*args, **kwargs):
-            async def _call():
-                future = asyncflow_task(*args, **kwargs)
-                return await future
-
-            return await _retry_async(_call, retry_cfg, name=asyncflow_task.__name__)
-
-        return tool(wrapper)
 
 
 # Minimal usage example (not executed):
@@ -197,10 +179,5 @@ class LangGraphIntegration:
 #     await asyncio.sleep(0.5)
 #     return f"Weather in {city} is sunny"
 #
-# @flow.function_task
-# async def existing_task(param: str) -> str:
-#     return f"Processed: {param}"
-#
-# tool_from_task = integration.to_langgraph_tool(existing_task)
-# tools = [get_weather, tool_from_task]
+# tools = [get_weather]
 """


### PR DESCRIPTION
BREAKING CHANGE: Removes the to_langraph_tool method from LangGraphIntegration class.

As mentioned by @javidsegura, the to_langraph_tool method was redundant with asyncflow_tool decorator.
Both provided the same functionality - converting async functions to LangChain tools with AsyncFlow management and retry logic.

Before: Two different APIs achieving the same result - @integration.asyncflow_tool (clean, single step) - integration.to_langraph_tool(existing_task) (unnecessary intermediate step)

After: Single, intuitive interface - @integration.asyncflow_tool (direct from function to tool)

This simplifies the API surface while maintaining all functionality. The single entry point reduces cognitive overhead and eliminates confusion about when to use which method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified LangGraph integration to a decorator-based tool declaration, removing the separate conversion step. This is a breaking change; migrate by annotating tasks directly and adding them to your tools list.

- Documentation
  - Updated README examples and guidance to reflect the decorator approach.
  - Removed references to the previous conversion helper from the API reference and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->