### PR TITLE
Hotfix/benchmarking engine and backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ examples-ca-asyncflow:  ## CrewAI + Asyncfow
 	$(VENV_ACTIVATE) && python3 -m examples.crewai_asyncflow
 examples-ag-asyncflow:  ## AutoGen + Asyncfow
 	$(VENV_ACTIVATE) && python3 -m examples.autogen_asyncflow
+examples-ac-asyncflow:  ## Academy + Asyncflow
+	$(VENV_ACTIVATE) && python3 -m examples.academy_asyncflow
 examples-lg-parsl:  ## AutoGen + Parsl
 	$(VENV_ACTIVATE) && python3 -m examples.langgraph_parsl
 examples-ag-parsl:  ## AutoGen + Parsl

--- a/examples/academy_asyncflow.py
+++ b/examples/academy_asyncflow.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+import time
+from dotenv import load_dotenv
+
+from radical.asyncflow import LocalExecutionBackend, WorkflowEngine
+from concurrent.futures import ThreadPoolExecutor
+
+from academy.agent import Agent, action
+from academy.exchange.local import LocalExchangeFactory
+from academy.manager import Manager
+
+from flowgentic.backend_engines.radical_asyncflow import AsyncFlowEngine
+from flowgentic.agent_orchestration_frameworks.academy import AcademyOrchestrator
+
+load_dotenv()
+
+# Configure Logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class WeatherAgent(Agent):
+	"""Academy agent that fetches weather data via HPC-backed tools."""
+
+	def __init__(self, fetch_temperature_fn, fetch_humidity_fn) -> None:
+		self._fetch_temperature = fetch_temperature_fn
+		self._fetch_humidity = fetch_humidity_fn
+
+	@action
+	async def get_weather(self, location: str = "SFO") -> dict:
+		"""Fetch temperature and humidity for a location."""
+		temperature = await self._fetch_temperature(location=location)
+		humidity = await self._fetch_humidity(location=location)
+		return {**temperature, **humidity}
+
+
+async def start_app():
+	# --- SETUP HPC BACKEND ---
+	backend = await LocalExecutionBackend(ThreadPoolExecutor(max_workers=2))
+	flow = await WorkflowEngine.create(backend)
+
+	# --- INITIALIZE FLOWGENTIC ---
+	engine = AsyncFlowEngine(flow)
+	orchestrator = AcademyOrchestrator(engine)
+
+	# --- DEFINE HPC TOOLS ---
+	@orchestrator.hpc_task
+	async def fetch_temperature(location: str = "SFO") -> dict:
+		"""Fetches temperature of a given city."""
+		logger.info(f"Executing temperature tool for {location}")
+		await asyncio.sleep(2)
+		return {"temperature": 70, "location": location}
+
+	@orchestrator.hpc_task
+	async def fetch_humidity(location: str = "SFO") -> dict:
+		"""Fetches humidity of a given city."""
+		logger.info(f"Executing humidity tool for {location}")
+		await asyncio.sleep(2)
+		return {"humidity": 50, "location": location}
+
+	# --- LAUNCH AGENT AND EXECUTE ---
+	t_start = time.perf_counter()
+
+	manager = await Manager.from_exchange_factory(
+		factory=LocalExchangeFactory(),
+		executors=None,
+	)
+
+	async with manager:
+		handle = await manager.launch(
+			WeatherAgent,
+			args=(fetch_temperature, fetch_humidity),
+		)
+		result = await handle.get_weather(location="SFO")
+		logger.info(f"Weather result: {result}")
+
+	t_end = time.perf_counter()
+	logger.info(f"Workflow finished in {t_end - t_start:.4f} seconds")
+
+	await flow.shutdown()
+
+
+if __name__ == "__main__":
+	asyncio.run(start_app())

--- a/src/flowgentic/agent_orchestration_frameworks/academy.py
+++ b/src/flowgentic/agent_orchestration_frameworks/academy.py
@@ -1,25 +1,23 @@
 from functools import wraps
 import time
 import uuid
-from typing import Any, Callable
+from typing import Callable
 
 from flowgentic.agent_orchestration_frameworks.base import AgentOrchestrator
 from flowgentic.backend_engines.base import BaseEngine
 
 
-class AutoGenOrchestrator(AgentOrchestrator):
+class AcademyOrchestrator(AgentOrchestrator):
 	def __init__(self, engine: BaseEngine) -> None:
 		self.engine = engine
 
 	def hpc_task(self, func: Callable):
 		"""
 		Wraps a function to execute as an HPC task.
-		AutoGen reads the signature from the wrapper (via @wraps).
 		"""
 		task_name = getattr(func, "__name__", str(func))
 		wrap_id = str(uuid.uuid4())
 
-		# Emit setup start event
 		self.engine.emit(
 			{
 				"event": "tool_wrap_start",
@@ -66,12 +64,11 @@ class AutoGenOrchestrator(AgentOrchestrator):
 
 	def hpc_block(self, block_func: Callable):
 		"""
-		Wraps a function to execute as an HPC block (coordinated work unit).
+		Wraps a function to execute as an HPC block.
 		"""
 		block_name = getattr(block_func, "__name__", str(block_func))
 		wrap_id = str(uuid.uuid4())
 
-		# Emit block wrap start event
 		self.engine.emit(
 			{
 				"event": "block_wrap_start",
@@ -83,7 +80,6 @@ class AutoGenOrchestrator(AgentOrchestrator):
 
 		wrapped_block = self.engine.wrap_node(block_func)
 
-		# Emit block wrap end event
 		self.engine.emit(
 			{
 				"event": "block_wrap_end",

--- a/src/flowgentic/backend_engines/parsl.py
+++ b/src/flowgentic/backend_engines/parsl.py
@@ -16,6 +16,7 @@ class ParslEngine(BaseEngine):
 		observer: Optional[Callable[[Dict[str, Any]], None]] = None,
 	):
 		super().__init__(observer=observer)
+		parsl.clear()
 		parsl.load(config)
 
 		self._task_registry: Dict[str, Any] = {}

--- a/src/flowgentic/core/models/implementations/dummy/autogen.py
+++ b/src/flowgentic/core/models/implementations/dummy/autogen.py
@@ -1,179 +1,179 @@
-# import uuid
-# from typing import Any, Dict, List, Optional
+import uuid
+from typing import Any, Dict, List, Optional
 
-# from autogen import AssistantAgent
-
-
-# class DummyAutoGenClient:
-# 	"""
-# 	A dummy AutoGen model client that returns deterministic responses.
-# 	Always triggers tool calls when tools are available, otherwise returns simple text.
-# 	"""
-
-# 	def __init__(self, config=None, **kwargs):
-# 		"""
-# 		Initialize the dummy client.
-# 		AutoGen passes config as first positional argument, then kwargs.
-# 		"""
-# 		# Merge config dict if provided
-# 		if isinstance(config, dict):
-# 			kwargs.update(config)
-# 		self.model = kwargs.get("model", "dummy-model")
-# 		self.fixed_tool_names = []
-
-# 	def create(self, params: Dict[str, Any]) -> Any:
-# 		"""
-# 		Create a chat completion response.
-# 		Returns a response object that implements ModelClientResponseProtocol.
-# 		"""
-# 		messages = params.get("messages", [])
-# 		tools = params.get("tools", [])
-
-# 		# Extract tool names if available
-# 		if tools:
-# 			self.fixed_tool_names = [
-# 				tool.get("function", {}).get("name", tool.get("name", ""))
-# 				for tool in tools
-# 				if tool.get("function", {}).get("name") or tool.get("name")
-# 			]
-
-# 		# Check if last message is a tool result
-# 		last_message = messages[-1] if messages else {}
-# 		if last_message.get("role") == "tool" or any(
-# 			msg.get("role") == "tool" for msg in messages[-3:]
-# 		):
-# 			# Return a simple completion after tool execution
-# 			return DummyResponse(
-# 				content="I have finished the HPC tasks. TERMINATE", model=self.model
-# 			)
-
-# 		# If tools are available, return tool calls
-# 		if self.fixed_tool_names:
-# 			tool_calls = []
-# 			for name in self.fixed_tool_names:
-# 				tool_calls.append(
-# 					{
-# 						"id": f"call_{uuid.uuid4().hex[:8]}",
-# 						"type": "function",
-# 						"function": {
-# 							"name": name,
-# 							"arguments": "{}",  # Empty args as requested
-# 						},
-# 					}
-# 				)
-
-# 			return DummyResponse(content="", tool_calls=tool_calls, model=self.model)
-
-# 		# Default: return a simple message
-# 		return DummyResponse(content="I understand. TERMINATE", model=self.model)
-
-# 	def message_retrieval(self, response: Any) -> List[Dict[str, Any]]:
-# 		"""
-# 		Extract messages from the response.
-# 		Returns a list of message dictionaries.
-# 		"""
-# 		messages = []
-# 		if hasattr(response, "choices") and response.choices:
-# 			choice = response.choices[0]
-# 			message = {
-# 				"role": "assistant",
-# 				"content": choice.message.get("content", ""),
-# 			}
-# 			if choice.message.get("tool_calls"):
-# 				message["tool_calls"] = choice.message["tool_calls"]
-# 			messages.append(message)
-# 		return messages
-
-# 	def cost(self, response: Any) -> float:
-# 		"""Return the cost of the response (always 0 for dummy)."""
-# 		return 0.0
-
-# 	def get_usage(self, response: Any) -> Dict[str, Any]:
-# 		"""
-# 		Return usage statistics.
-# 		Must include: prompt_tokens, completion_tokens, total_tokens, cost, model
-# 		"""
-# 		return {
-# 			"prompt_tokens": 10,
-# 			"completion_tokens": 5,
-# 			"total_tokens": 15,
-# 			"cost": 0.0,
-# 			"model": self.model,
-# 		}
+from autogen import AssistantAgent
 
 
-# class DummyResponse:
-# 	"""
-# 	A simple response object that implements ModelClientResponseProtocol.
-# 	"""
+class DummyAutoGenClient:
+	"""
+	A dummy AutoGen model client that returns deterministic responses.
+	Always triggers tool calls when tools are available, otherwise returns simple text.
+	"""
 
-# 	def __init__(
-# 		self, content: str, model: str, tool_calls: Optional[List[Dict]] = None
-# 	):
-# 		self.model = model
-# 		self.choices = [DummyChoice(content, tool_calls)]
+	def __init__(self, config=None, **kwargs):
+		"""
+		Initialize the dummy client.
+		AutoGen passes config as first positional argument, then kwargs.
+		"""
+		# Merge config dict if provided
+		if isinstance(config, dict):
+			kwargs.update(config)
+		self.model = kwargs.get("model", "dummy-model")
+		self.fixed_tool_names = []
 
-# 	def __getattr__(self, name: str) -> Any:
-# 		"""Handle any other attributes that might be accessed."""
-# 		return None
+	def create(self, params: Dict[str, Any]) -> Any:
+		"""
+		Create a chat completion response.
+		Returns a response object that implements ModelClientResponseProtocol.
+		"""
+		messages = params.get("messages", [])
+		tools = params.get("tools", [])
+
+		# Extract tool names if available
+		if tools:
+			self.fixed_tool_names = [
+				tool.get("function", {}).get("name", tool.get("name", ""))
+				for tool in tools
+				if tool.get("function", {}).get("name") or tool.get("name")
+			]
+
+		# Check if last message is a tool result
+		last_message = messages[-1] if messages else {}
+		if last_message.get("role") == "tool" or any(
+			msg.get("role") == "tool" for msg in messages[-3:]
+		):
+			# Return a simple completion after tool execution
+			return DummyResponse(
+				content="I have finished the HPC tasks. TERMINATE", model=self.model
+			)
+
+		# If tools are available, return tool calls
+		if self.fixed_tool_names:
+			tool_calls = []
+			for name in self.fixed_tool_names:
+				tool_calls.append(
+					{
+						"id": f"call_{uuid.uuid4().hex[:8]}",
+						"type": "function",
+						"function": {
+							"name": name,
+							"arguments": "{}",  # Empty args as requested
+						},
+					}
+				)
+
+			return DummyResponse(content="", tool_calls=tool_calls, model=self.model)
+
+		# Default: return a simple message
+		return DummyResponse(content="I understand. TERMINATE", model=self.model)
+
+	def message_retrieval(self, response: Any) -> List[Dict[str, Any]]:
+		"""
+		Extract messages from the response.
+		Returns a list of message dictionaries.
+		"""
+		messages = []
+		if hasattr(response, "choices") and response.choices:
+			choice = response.choices[0]
+			message = {
+				"role": "assistant",
+				"content": choice.message.get("content", ""),
+			}
+			if choice.message.get("tool_calls"):
+				message["tool_calls"] = choice.message["tool_calls"]
+			messages.append(message)
+		return messages
+
+	def cost(self, response: Any) -> float:
+		"""Return the cost of the response (always 0 for dummy)."""
+		return 0.0
+
+	def get_usage(self, response: Any) -> Dict[str, Any]:
+		"""
+		Return usage statistics.
+		Must include: prompt_tokens, completion_tokens, total_tokens, cost, model
+		"""
+		return {
+			"prompt_tokens": 10,
+			"completion_tokens": 5,
+			"total_tokens": 15,
+			"cost": 0.0,
+			"model": self.model,
+		}
 
 
-# class DummyChoice:
-# 	"""A choice object within the response."""
+class DummyResponse:
+	"""
+	A simple response object that implements ModelClientResponseProtocol.
+	"""
 
-# 	def __init__(self, content: str, tool_calls: Optional[List[Dict]] = None):
-# 		self.message = {
-# 			"role": "assistant",
-# 			"content": content,
-# 		}
-# 		if tool_calls:
-# 			self.message["tool_calls"] = tool_calls
+	def __init__(
+		self, content: str, model: str, tool_calls: Optional[List[Dict]] = None
+	):
+		self.model = model
+		self.choices = [DummyChoice(content, tool_calls)]
+
+	def __getattr__(self, name: str) -> Any:
+		"""Handle any other attributes that might be accessed."""
+		return None
 
 
-# def create_assistant_with_dummy_model(
-# 	name: str, system_message: str, model: str = "dummy-model", **kwargs
-# ) -> AssistantAgent:
-# 	"""
-# 	Helper function to create an AssistantAgent with DummyAutoGenClient.
-# 	This handles all the setup needed for using the dummy model client.
+class DummyChoice:
+	"""A choice object within the response."""
 
-# 	Args:
-# 	    name: Name of the assistant agent
-# 	    system_message: System message for the agent
-# 	    model: Model name (default: "dummy-model")
-# 	    **kwargs: Additional arguments to pass to AssistantAgent
+	def __init__(self, content: str, tool_calls: Optional[List[Dict]] = None):
+		self.message = {
+			"role": "assistant",
+			"content": content,
+		}
+		if tool_calls:
+			self.message["tool_calls"] = tool_calls
 
-# 	Returns:
-# 	    AssistantAgent configured with DummyAutoGenClient
-# 	"""
-# 	from autogen.oai.client import OpenAIWrapper
 
-# 	# Set up config with dummy model client
-# 	model_config = {
-# 		"model": model,
-# 		"model_client_cls": "DummyAutoGenClient",
-# 	}
+def create_assistant_with_dummy_model(
+	name: str, system_message: str, model: str = "dummy-model", **kwargs
+) -> AssistantAgent:
+	"""
+	Helper function to create an AssistantAgent with DummyAutoGenClient.
+	This handles all the setup needed for using the dummy model client.
 
-# 	llm_config = {
-# 		"config_list": [model_config],
-# 		"temperature": 0,
-# 	}
+	Args:
+	    name: Name of the assistant agent
+	    system_message: System message for the agent
+	    model: Model name (default: "dummy-model")
+	    **kwargs: Additional arguments to pass to AssistantAgent
 
-# 	# Create agent without LLM config first to avoid AutoGen creating its own client
-# 	agent = AssistantAgent(
-# 		name=name, llm_config=False, system_message=system_message, **kwargs
-# 	)
+	Returns:
+	    AssistantAgent configured with DummyAutoGenClient
+	"""
+	from autogen.oai.client import OpenAIWrapper
 
-# 	# Create client wrapper and register the dummy model client
-# 	client = OpenAIWrapper(**llm_config)
-# 	client.register_model_client(model_client_cls=DummyAutoGenClient)
+	# Set up config with dummy model client
+	model_config = {
+		"model": model,
+		"model_client_cls": "DummyAutoGenClient",
+	}
 
-# 	# Verify registration worked
-# 	if not any(isinstance(c, DummyAutoGenClient) for c in client._clients):
-# 		raise RuntimeError("Failed to register DummyAutoGenClient")
+	llm_config = {
+		"config_list": [model_config],
+		"temperature": 0,
+	}
 
-# 	# Set the llm_config and client on the agent
-# 	agent.llm_config = llm_config
-# 	agent.client = client
+	# Create agent without LLM config first to avoid AutoGen creating its own client
+	agent = AssistantAgent(
+		name=name, llm_config=False, system_message=system_message, **kwargs
+	)
 
-# 	return agent
+	# Create client wrapper and register the dummy model client
+	client = OpenAIWrapper(**llm_config)
+	client.register_model_client(model_client_cls=DummyAutoGenClient)
+
+	# Verify registration worked
+	if not any(isinstance(c, DummyAutoGenClient) for c in client._clients):
+		raise RuntimeError("Failed to register DummyAutoGenClient")
+
+	# Set the llm_config and client on the agent
+	agent.llm_config = llm_config
+	agent.client = client
+
+	return agent

--- a/src/flowgentic/core/models/implementations/dummy/autogen.py
+++ b/src/flowgentic/core/models/implementations/dummy/autogen.py
@@ -19,6 +19,7 @@ class DummyAutoGenClient:
 		if isinstance(config, dict):
 			kwargs.update(config)
 		self.model = kwargs.get("model", "dummy-model")
+		self.calls_per_tool = kwargs.get("calls_per_tool", 1)
 		self.fixed_tool_names = []
 
 	def create(self, params: Dict[str, Any]) -> Any:
@@ -50,17 +51,18 @@ class DummyAutoGenClient:
 		# If tools are available, return tool calls
 		if self.fixed_tool_names:
 			tool_calls = []
-			for name in self.fixed_tool_names:
-				tool_calls.append(
-					{
-						"id": f"call_{uuid.uuid4().hex[:8]}",
-						"type": "function",
-						"function": {
-							"name": name,
-							"arguments": "{}",  # Empty args as requested
-						},
-					}
-				)
+			for _ in range(self.calls_per_tool):
+				for name in self.fixed_tool_names:
+					tool_calls.append(
+						{
+							"id": f"call_{uuid.uuid4().hex[:8]}",
+							"type": "function",
+							"function": {
+								"name": name,
+								"arguments": "{}",  # Empty args as requested
+							},
+						}
+					)
 
 			return DummyResponse(content="", tool_calls=tool_calls, model=self.model)
 
@@ -131,7 +133,7 @@ class DummyChoice:
 
 
 def create_assistant_with_dummy_model(
-	name: str, system_message: str, model: str = "dummy-model", **kwargs
+	name: str, system_message: str, model: str = "dummy-model", calls_per_tool: int = 1, **kwargs
 ) -> AssistantAgent:
 	"""
 	Helper function to create an AssistantAgent with DummyAutoGenClient.
@@ -152,6 +154,7 @@ def create_assistant_with_dummy_model(
 	model_config = {
 		"model": model,
 		"model_client_cls": "DummyAutoGenClient",
+		"calls_per_tool": calls_per_tool,
 	}
 
 	llm_config = {

--- a/src/flowgentic/core/models/implementations/dummy/autogen.py
+++ b/src/flowgentic/core/models/implementations/dummy/autogen.py
@@ -133,7 +133,11 @@ class DummyChoice:
 
 
 def create_assistant_with_dummy_model(
-	name: str, system_message: str, model: str = "dummy-model", calls_per_tool: int = 1, **kwargs
+	name: str,
+	system_message: str,
+	model: str = "dummy-model",
+	calls_per_tool: int = 1,
+	**kwargs,
 ) -> AssistantAgent:
 	"""
 	Helper function to create an AssistantAgent with DummyAutoGenClient.


### PR DESCRIPTION
- Academy support: added AcademyOrchestrationFramework adapter alongside AutoGen/LangGraph
- Parsl fix: fixed clear() not properly resetting the Parsl backend between runs
- AutoGen events: renamed event emission in the AutoGen to align with the new event model
- Dummy model: added calls_per_tool param to DummyAutoGenClient
